### PR TITLE
FIX: Do not error if there are no comments

### DIFF
--- a/assets/javascripts/discourse/widgets/qa-comments.js.es6
+++ b/assets/javascripts/discourse/widgets/qa-comments.js.es6
@@ -6,13 +6,13 @@ export default createWidget("qa-comments", {
 
   defaultState(attrs) {
     return {
-      comments: attrs.comments,
+      comments: attrs.comments || [],
     };
   },
 
   html(attrs, state) {
-    const result = [];
-    const postCommentsLength = state.comments.length || 0;
+    const result = [],
+      postCommentsLength = state.comments.length;
 
     if (postCommentsLength > 0) {
       for (let i = 0; i < postCommentsLength; i++) {


### PR DESCRIPTION
This fixes an issue where posting an answer results in a JS error.