### PR TITLE
FEATURE: Switch to a custom comments model.

### DIFF
--- a/app/models/question_answer_comment.rb
+++ b/app/models/question_answer_comment.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class QuestionAnswerComment < ActiveRecord::Base
+  include Trashable
+
+  # Bump this when changing MARKDOWN_FEATURES or MARKDOWN_IT_RULES
+  COOKED_VERSION = 1
+
+  belongs_to :post
+  belongs_to :user
+
+  validates :post_id, presence: true
+  validates :user_id, presence: true
+  validates :raw, presence: true
+  validates :cooked, presence: true
+  validates :cooked_version, presence: true
+
+  validate :ensure_can_comment, on: [:create]
+  before_validation :cook_raw, if: :will_save_change_to_raw?
+
+  MARKDOWN_FEATURES = %w{
+    censored
+    emoji
+  }
+
+  MARKDOWN_IT_RULES = %w{
+    emphasis
+    backticks
+    linkify
+    link
+  }
+
+  def self.cook(raw)
+    raw.gsub!(/(\n)+/, " ")
+    PrettyText.cook(raw, features_override: MARKDOWN_FEATURES, markdown_it_rules: MARKDOWN_IT_RULES)
+  end
+
+  private
+
+  def cook_raw
+    self.cooked = self.class.cook(self.raw)
+    self.cooked_version = COOKED_VERSION #TODO automatic rebaking once version is bumped
+  end
+
+  def ensure_can_comment
+    if !post.qa_enabled
+      errors.add(:base, I18n.t("qa.comment.errors.qa_not_enabled"))
+    elsif post.reply_to_post_number.present?
+      errors.add(:base, I18n.t("qa.comment.errors.not_permitted"))
+    elsif self.class.where(post_id: self.post_id).count >= SiteSetting.qa_comment_limit_per_post
+      errors.add(:base, I18n.t("qa.comment.errors.limit_exceeded", limit: SiteSetting.qa_comment_limit_per_post))
+    end
+  end
+end

--- a/app/serializers/question_answer_comment_serializer.rb
+++ b/app/serializers/question_answer_comment_serializer.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-class QuestionAnswer::CommentSerializer < ApplicationSerializer
+class QuestionAnswerCommentSerializer < ApplicationSerializer
   attributes :id,
-             :post_number,
              :name,
              :username,
              :created_at,

--- a/assets/javascripts/discourse/widgets/qa-comments.js
+++ b/assets/javascripts/discourse/widgets/qa-comments.js
@@ -25,8 +25,8 @@ export default createWidget("qa-comments", {
         this.attach("qa-comments-menu", {
           id: attrs.id,
           moreCommentCount: attrs.comments_count - postCommentsLength,
-          lastPostNumber: state.comments
-            ? state.comments[state.comments.length - 1]?.post_number || 0
+          lastCommentId: state.comments
+            ? state.comments[state.comments.length - 1]?.id || 0
             : 0,
         })
       );

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,14 +2,14 @@ en:
   post:
     qa:
       errors:
-        depth: "Only one level of nesting allowed when replying to a post."
+        replying_to_post_not_permited: "You are not allowed to create a post in reply to another post."
         qa_not_enabled: "QnA is not enabled."
         voting_not_permitted: "You are not allowed to vote on this post."
 
   site_settings:
     qa_tags: "Tags to enable QnA on topic"
     qa_show_topic_tip: "Show a tip about the mechanics of QnA topics under the titles of QnA topics"
-    qa_enabled: "Enable QA Plugin"
+    qa_enabled: "Enable QnA Plugin"
     qa_disable_like_on_answers: "Disables like button on answers in QnA topics"
     qa_undo_vote_action_window: "Number of minutes users are allowed to undo votes in QnA topics (enter 0 for no limit)"
     qa_trust_level_vote_limits: "Use trust level vote limits for the question and answer plugin"
@@ -18,6 +18,7 @@ en:
     qa_tl3_vote_limit: "The vote limit for the question and answer plugin for trust level 3 users"
     qa_tl4_vote_limit: "The vote limit for the question and answer plugin for trust level 4 users"
     qa_blacklist_tags: "Tags to disable QnA on topic"
+    qa_comment_limit_per_post: "Number of comments allowed on each question or answer"
 
   post_action_types:
     vote:
@@ -33,3 +34,10 @@ en:
       already_voted: "You can only vote once per question."
       undo_vote_action_window: "You can only undo votes %{minutes} after voting."
       one_vote_per_post: "You can only vote once for each post."
+
+  qa:
+    comment:
+      errors:
+        qa_not_enabled: "QnA is not enabled."
+        not_permitted: "Commenting on associated post is not permitted."
+        limit_exceeded: "Limit of %{limit} comments per post has been reached."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ QuestionAnswer::Engine.routes.draw do
   get 'voters' => 'votes#voters'
   post 'set_as_answer' => 'votes#set_as_answer'
 
-  get "comments" => 'comments#load_comments'
+  get "comments" => 'comments#load_more_comments'
   post "comments" => 'comments#create'
 end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -32,3 +32,7 @@ plugins:
   qa_blacklist_tags:
     type: list
     default: ""
+  qa_comment_limit_per_post:
+    default: 10
+    min: 1
+    client: true

--- a/db/migrate/20211208073658_create_question_answer_comments.rb
+++ b/db/migrate/20211208073658_create_question_answer_comments.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateQuestionAnswerComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :question_answer_comments do |t|
+      t.integer :post_id, null: false
+      t.integer :user_id, null: false
+      t.text :raw, null: false
+      t.text :cooked, null: false
+      t.integer :cooked_version
+      t.datetime :deleted_at
+      t.integer :deleted_by_id
+
+      t.timestamps
+    end
+
+    add_index :question_answer_comments, :post_id
+    add_index :question_answer_comments, :user_id
+    add_index :question_answer_comments, :deleted_by_id, where: "deleted_by_id IS NOT NULL"
+  end
+end

--- a/extensions/post_extension.rb
+++ b/extensions/post_extension.rb
@@ -6,8 +6,7 @@ module QuestionAnswer
       base.ignored_columns = %w[vote_count]
 
       base.has_many :question_answer_votes
-
-      base.validate :ensure_valid_qa_comment
+      base.validate :ensure_only_answer
     end
 
     def qa_enabled
@@ -35,13 +34,13 @@ module QuestionAnswer
 
     private
 
-    def ensure_valid_qa_comment
+    def ensure_only_answer
       if will_save_change_to_reply_to_post_number? &&
           reply_to_post_number &&
-          !Post.exists?(topic_id: topic_id, reply_to_post_number: nil, post_number: reply_to_post_number) &&
+          reply_to_post_number != 1 &&
           qa_enabled
 
-        errors.add(:base, I18n.t("post.qa.errors.depth"))
+        errors.add(:base, I18n.t("post.qa.errors.replying_to_post_not_permited"))
       end
     end
   end

--- a/extensions/post_serializer_extension.rb
+++ b/extensions/post_serializer_extension.rb
@@ -22,8 +22,8 @@ module QuestionAnswer
     end
 
     def comments
-      (@topic_view.comments[object.post_number] || []).map do |post|
-        QuestionAnswer::CommentSerializer.new(post, scope: scope, root: false).as_json
+      (@topic_view.comments[object.id] || []).map do |comment|
+        QuestionAnswerCommentSerializer.new(comment, scope: scope, root: false).as_json
       end
     end
 

--- a/extensions/topic_extension.rb
+++ b/extensions/topic_extension.rb
@@ -34,22 +34,20 @@ module QuestionAnswer
 
     def comments
       @comments ||= begin
-        posts
-          .where.not(reply_to_post_number: nil)
-          .order(post_number: :asc)
+        QuestionAnswerComment.joins(:post).where("posts.topic_id = ?", self.id)
       end
     end
 
     def last_commented_on
       return unless comments.present?
 
-      comments.last[:created_at]
+      comments.last.created_at
     end
 
     def last_answer_post_number
       return unless answers.any?
 
-      answers.last[:post_number]
+      answers.last.post_number
     end
 
     def last_answerer

--- a/extensions/topic_view_extension.rb
+++ b/extensions/topic_view_extension.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module QuestionAnswer
+  module TopicViewExtension
+    def self.included(base)
+      base.attr_accessor(
+        :comments,
+        :comments_counts,
+        :posts_user_voted,
+        :posts_voted_on
+      )
+
+      unless base.const_defined?(:PRELOAD_COMMENTS_COUNT)
+        base.const_set :PRELOAD_COMMENTS_COUNT, 5
+      end
+    end
+  end
+end

--- a/extensions/user_extension.rb
+++ b/extensions/user_extension.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module QuestionAnswer
+  module UserExtension
+    def self.included(base)
+      base.has_many :question_answer_votes
+    end
+  end
+end

--- a/spec/fabricators/question_answer_comment_fabricator.rb
+++ b/spec/fabricators/question_answer_comment_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator(:qa_comment, class_name: :question_answer_comment) do
+  user
+  post
+  raw "Hello world"
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -18,19 +18,13 @@ describe Post do
   end
 
   context "validation" do
-    it "ensures that comments are only nested one level deep" do
-      post_2 = Fabricate(:post, reply_to_post_number: post.post_number, topic: post.topic)
+    it "ensures that post cannot be created with reply_to_post_number set" do
+      post.reply_to_post_number = 3
 
-      post_3 = Fabricate.build(:post,
-        reply_to_post_number: post_2.post_number,
-        topic: post.topic,
-        user: post_2.user
-      )
+      expect(post.valid?).to eq(false)
 
-      expect(post_3.valid?).to eq(false)
-
-      expect(post_3.errors.full_messages).to contain_exactly(
-        I18n.t("post.qa.errors.depth")
+      expect(post.errors.full_messages).to contain_exactly(
+        I18n.t("post.qa.errors.replying_to_post_not_permited")
       )
     end
   end

--- a/spec/models/question_answer_comment_spec.rb
+++ b/spec/models/question_answer_comment_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe QuestionAnswerComment do
+  fab!(:post) { Fabricate(:post) }
+  fab!(:user) { Fabricate(:user) }
+  fab!(:tag) { Fabricate(:tag) }
+
+  before do
+    SiteSetting.qa_enabled = true
+    SiteSetting.qa_tags = tag.name
+    post.topic.tags << tag
+  end
+
+  context 'validations' do
+    it 'does not allow comments to be created when qa is disabled' do
+      SiteSetting.qa_enabled = false
+
+      qa_comment = QuestionAnswerComment.new(raw: 'this is a **post**', post: post, user: user)
+
+      expect(qa_comment.valid?).to eq(false)
+      expect(qa_comment.errors.full_messages).to contain_exactly(I18n.t("qa.comment.errors.qa_not_enabled"))
+    end
+
+    it 'does not allow comments to be created when post is in reply to another post' do
+      SiteSetting.qa_enabled = false
+      post.update!(reply_to_post_number: 2)
+      SiteSetting.qa_enabled = true
+
+      qa_comment = QuestionAnswerComment.new(raw: 'this is a **post**', post: post, user: user)
+
+      expect(qa_comment.valid?).to eq(false)
+      expect(qa_comment.errors.full_messages).to contain_exactly(I18n.t("qa.comment.errors.not_permitted"))
+    end
+
+    it 'does not allow comments to be created when SiteSetting.qa_comment_limit_per_post has been reached' do
+      SiteSetting.qa_comment_limit_per_post = 1
+
+      QuestionAnswerComment.create!(raw: 'this is a **post**', post: post, user: user)
+      qa_comment = QuestionAnswerComment.new(raw: 'this is a **post**', post: post, user: user)
+
+      expect(qa_comment.valid?).to eq(false)
+
+      expect(qa_comment.errors.full_messages).to contain_exactly(
+        I18n.t("qa.comment.errors.limit_exceeded", limit: SiteSetting.qa_comment_limit_per_post)
+      )
+    end
+  end
+
+  context 'callbacks' do
+    it 'cooks raw before saving' do
+      qa_comment = QuestionAnswerComment.new(raw: 'this is a **post**', post: post, user: user)
+
+      expect(qa_comment.valid?).to eq(true)
+      expect(qa_comment.cooked).to eq("<p>this is a <strong>post</strong></p>")
+      expect(qa_comment.cooked_version).to eq(described_class::COOKED_VERSION)
+    end
+  end
+
+  describe '.cook' do
+    it 'supports emphasis markdown rule' do
+      qa_comment = Fabricate(:qa_comment, post: post, raw: "**bold**")
+
+      expect(qa_comment.cooked).to eq("<p><strong>bold</strong></p>")
+    end
+
+    it 'supports backticks markdown rule' do
+      qa_comment = Fabricate(:qa_comment, post: post, raw: "`test`")
+
+      expect(qa_comment.cooked).to eq("<p><code>test</code></p>")
+    end
+
+    it 'supports link markdown rule' do
+      qa_comment = Fabricate(:qa_comment, post: post, raw: "[test link](https://www.example.com)")
+
+      expect(qa_comment.cooked).to eq("<p><a href=\"https://www.example.com\" rel=\"noopener nofollow ugc\">test link</a></p>")
+    end
+
+    it 'supports linkify markdown rule' do
+      qa_comment = Fabricate(:qa_comment, post: post, raw: "https://www.example.com")
+
+      expect(qa_comment.cooked).to eq("<p><a href=\"https://www.example.com\" rel=\"noopener nofollow ugc\">https://www.example.com</a></p>")
+    end
+
+    it 'supports emoji markdown engine' do
+      qa_comment = Fabricate(:qa_comment, post: post, raw: ':grin:')
+
+      expect(qa_comment.cooked).to eq("<p><img src=\"/images/emoji/twitter/grin.png?v=#{Emoji::EMOJI_VERSION}\" title=\":grin:\" class=\"emoji only-emoji\" alt=\":grin:\"></p>")
+    end
+
+    it 'supports censored markdown engine' do
+      watched_word = Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "testing")
+
+      qa_comment = Fabricate(:qa_comment, post: post, raw: watched_word.word)
+
+      expect(qa_comment.cooked).to eq("<p>■■■■■■■</p>")
+    end
+
+    it 'removes newlines from raw as comments should only support a single paragraph' do
+      qa_comment = Fabricate(:qa_comment, post: post, raw: <<~RAW)
+      line 1
+
+      line 2
+      RAW
+
+      expect(qa_comment.cooked).to eq("<p>line 1 line 2</p>")
+    end
+  end
+end

--- a/spec/models/question_answer_vote_spec.rb
+++ b/spec/models/question_answer_vote_spec.rb
@@ -11,7 +11,6 @@ describe QuestionAnswerVote do
     SiteSetting.qa_enabled = true
     SiteSetting.qa_tags = tag.name
     post.topic.tags << tag
-
   end
 
   context 'validations' do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2,10 +2,6 @@
 
 require 'rails_helper'
 
-Fabricator(:comment, from: :post) do
-  reply_to_post_number
-end
-
 describe Topic do
   fab!(:user) { Fabricate(:user) }
   fab!(:category) { Fabricate(:category) }
@@ -16,13 +12,11 @@ describe Topic do
     5.times.map { Fabricate(:post, topic: topic) }.sort_by(&:created_at)
   end
 
-  fab!(:comments) do
+  let(:comments) do
+    answer = answers.first
+
     5.times.map do
-      Fabricate(
-        :comment,
-        topic: topic,
-        reply_to_post_number: 2
-      )
+      Fabricate(:qa_comment, post: answer)
     end.sort_by(&:created_at)
   end
 
@@ -31,6 +25,7 @@ describe Topic do
   before do
     SiteSetting.qa_tags = tag.name
     topic.tags << tag
+    comments
   end
 
   let(:up) { QuestionAnswerVote.directions[:up] }

--- a/spec/serializers/question_answer/comment_serializer_spec.rb
+++ b/spec/serializers/question_answer/comment_serializer_spec.rb
@@ -2,18 +2,25 @@
 
 require 'rails_helper'
 
-describe QuestionAnswer::CommentSerializer do
-  fab!(:post) { Fabricate(:post) }
-  let(:serializer) { described_class.new(post) }
+describe QuestionAnswerCommentSerializer do
+  fab!(:tag) { Fabricate(:tag) }
+  fab!(:topic) { Fabricate(:topic, tags: [tag]) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
+  let(:qa_comment) { Fabricate(:qa_comment, post: post) }
+  let(:serializer) { described_class.new(qa_comment) }
+
+  before do
+    SiteSetting.qa_enabled = true
+    SiteSetting.qa_tags = tag.name
+  end
 
   it 'returns the right attributes' do
-    serilized_comment = serializer.as_json[:comment]
+    serilized_comment = serializer.as_json[:question_answer_comment]
 
-    expect(serilized_comment[:id]).to eq(post.id)
-    expect(serilized_comment[:post_number]).to eq(post.post_number)
-    expect(serilized_comment[:created_at]).to eq(post.created_at)
-    expect(serilized_comment[:cooked]).to eq(post.cooked)
-    expect(serilized_comment[:name]).to eq(post.user.name)
-    expect(serilized_comment[:username]).to eq(post.user.username)
+    expect(serilized_comment[:id]).to eq(qa_comment.id)
+    expect(serilized_comment[:created_at]).to eq(qa_comment.created_at)
+    expect(serilized_comment[:cooked]).to eq(qa_comment.cooked)
+    expect(serilized_comment[:name]).to eq(qa_comment.user.name)
+    expect(serilized_comment[:username]).to eq(qa_comment.user.username)
   end
 end

--- a/spec/serializers/question_answer/post_serializer_spec.rb
+++ b/spec/serializers/question_answer/post_serializer_spec.rb
@@ -8,7 +8,7 @@ describe QuestionAnswer::PostSerializerExtension do
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:post) { Fabricate(:post, topic: topic, post_number: 1) }
   fab!(:answer) { Fabricate(:post, topic: topic, post_number: 2) }
-  fab!(:comment) { create_post(topic: topic, reply_to_post_number: answer.post_number) }
+  let(:comment) { Fabricate(:qa_comment, post: answer) }
   let(:topic_view) { TopicView.new(topic, user) }
   let(:up) { QuestionAnswerVote.directions[:up] }
   let(:guardian) { Guardian.new(user) }
@@ -24,6 +24,7 @@ describe QuestionAnswer::PostSerializerExtension do
       category.custom_fields['qa_enabled'] = true
       category.save!
       category.reload
+      comment
     end
 
     it 'should return the right attributes' do

--- a/spec/serializers/question_answer/topic_view_serializer_spec.rb
+++ b/spec/serializers/question_answer/topic_view_serializer_spec.rb
@@ -13,13 +13,14 @@ describe QuestionAnswer::TopicViewSerializerExtension do
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
   fab!(:answer) { Fabricate(:post, topic: topic, reply_to_post_number: nil) }
-  fab!(:comment) { Fabricate(:post, reply_to_post_number: answer.post_number, topic: topic) }
+  let(:comment) { Fabricate(:qa_comment, post: answer) }
   fab!(:user) { Fabricate(:user) }
   fab!(:guardian) { Guardian.new(user) }
   let(:topic_view) { TopicView.new(topic, user) }
 
   before do
     SiteSetting.qa_enabled = true
+    comment
   end
 
   it 'should return correct values' do


### PR DESCRIPTION
This PR switches commenting in a Q&A topic to be backed by a custom class instead of using the `Post` model. This is done as we want to decouple ourselves from all the baggage that comes with the `Post` model. For example, creating a post bumps `Topic#highest_post_number` but the comments are not actually displayed as part of the post stream. This bump in the post number messes up unread making things hard to reason about.  

### Screenshots

![Screenshot from 2022-01-13 13-51-48](https://user-images.githubusercontent.com/4335742/149273455-43656d45-c3cf-481a-ab5d-5728075ce3cc.png)
