### PR TITLE
FEATURE: Add some logic for topic list linking

### DIFF
--- a/assets/javascripts/discourse/initializers/qa-edits.js
+++ b/assets/javascripts/discourse/initializers/qa-edits.js
@@ -55,7 +55,7 @@ function initPlugin(api) {
   });
 
   function customLastUnreadUrl(context) {
-    if (context.qa_enabled && context.last_read_post_number) {
+    if (context.is_qa && context.last_read_post_number) {
       if (context.highest_post_number <= context.last_read_post_number) {
         // link to OP if no unread
         return context.urlForPostNumber(1);

--- a/assets/javascripts/discourse/initializers/qa-edits.js
+++ b/assets/javascripts/discourse/initializers/qa-edits.js
@@ -1,3 +1,4 @@
+import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { readOnly } from "@ember/object/computed";
@@ -51,6 +52,29 @@ function initPlugin(api) {
     orderStreamByVotes() {
       this.cancelFilter();
       return this.refreshAndJumptoSecondVisible();
+    },
+  });
+
+  api.modifyClass("model:topic", {
+    pluginId,
+
+    @discourseComputed("last_read_post_number", "highest_post_number", "url")
+    lastUnreadUrl(lastReadPostNumber, highestPostNumber) {
+      if (this.qa_enabled) {
+        if (highestPostNumber <= lastReadPostNumber) {
+          // link to OP if no unread
+          return this.urlForPostNumber(1);
+        } else if (lastReadPostNumber === highestPostNumber - 1) {
+          return this.urlForPostNumber(lastReadPostNumber + 1);
+        } else {
+          // sort by activity if user has 2+ unread posts
+          return `${this.urlForPostNumber(
+            lastReadPostNumber + 1
+          )}?filter=activity`;
+        }
+      }
+
+      return this._super(...arguments);
     },
   });
 

--- a/assets/javascripts/discourse/initializers/qa-edits.js
+++ b/assets/javascripts/discourse/initializers/qa-edits.js
@@ -1,4 +1,3 @@
-import discourseComputed from "discourse-common/utils/decorators";
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { readOnly } from "@ember/object/computed";
@@ -55,28 +54,25 @@ function initPlugin(api) {
     },
   });
 
-  api.modifyClass("model:topic", {
-    pluginId,
-
-    @discourseComputed("last_read_post_number", "highest_post_number", "url")
-    lastUnreadUrl(lastReadPostNumber, highestPostNumber) {
-      if (this.qa_enabled) {
-        if (highestPostNumber <= lastReadPostNumber) {
-          // link to OP if no unread
-          return this.urlForPostNumber(1);
-        } else if (lastReadPostNumber === highestPostNumber - 1) {
-          return this.urlForPostNumber(lastReadPostNumber + 1);
-        } else {
-          // sort by activity if user has 2+ unread posts
-          return `${this.urlForPostNumber(
-            lastReadPostNumber + 1
-          )}?filter=activity`;
-        }
+  function customLastUnreadUrl(context) {
+    if (context.qa_enabled && context.last_read_post_number) {
+      if (context.highest_post_number <= context.last_read_post_number) {
+        // link to OP if no unread
+        return context.urlForPostNumber(1);
+      } else if (
+        context.last_read_post_number ===
+        context.highest_post_number - 1
+      ) {
+        return context.urlForPostNumber(context.last_read_post_number + 1);
+      } else {
+        // sort by activity if user has 2+ unread posts
+        return `${context.urlForPostNumber(
+          context.last_read_post_number + 1
+        )}?filter=activity`;
       }
-
-      return this._super(...arguments);
-    },
-  });
+    }
+  }
+  api.registerCustomLastUnreadUrlCallback(customLastUnreadUrl);
 
   api.reopenWidget("post", {
     orderByVotes() {
@@ -225,6 +221,6 @@ export default {
       return;
     }
 
-    withPluginApi("0.13.0", initPlugin);
+    withPluginApi("1.2.0", initPlugin);
   },
 };

--- a/extensions/topic_list_item_serializer_extension.rb
+++ b/extensions/topic_list_item_serializer_extension.rb
@@ -3,15 +3,15 @@
 module QuestionAnswer
   module TopicListItemSerializerExtension
     def self.included(base)
-      base.attributes :qa_enabled
+      base.attributes :is_qa
     end
 
-    def qa_enabled
-      object.qa_enabled
+    def is_qa
+      object.is_qa?
     end
 
-    def include_qa_enabled?
-      object.qa_enabled
+    def include_is_qa?
+      object.is_qa?
     end
   end
 end

--- a/extensions/topic_list_item_serializer_extension.rb
+++ b/extensions/topic_list_item_serializer_extension.rb
@@ -2,19 +2,16 @@
 
 module QuestionAnswer
   module TopicListItemSerializerExtension
-    # For Q&A topics, we always want to link to the first post because timeline
-    # ordering is not consistent with last unread.
-    def last_read_post_number
-      return nil if object.is_qa?
-      super
+    def self.included(base)
+      base.attributes :qa_enabled
     end
 
-    def include_last_read_post_number?
-      if object.is_qa?
-        true
-      else
-        super
-      end
+    def qa_enabled
+      object.qa_enabled
+    end
+
+    def include_qa_enabled?
+      object.qa_enabled
     end
   end
 end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -28,8 +28,8 @@ describe ListController do
     qa = topics.find { |t| t["id"] == qa_topic.id }
     non_qa = topics.find { |t| t["id"] == topic.id }
 
-    expect(qa["qa_enabled"]).to eq(true)
-    expect(non_qa["qa_enabled"]).to eq(nil)
+    expect(qa["is_qa"]).to eq(true)
+    expect(non_qa["is_qa"]).to eq(nil)
   end
 
   it 'should return the right attributes when Q&A is disabled' do
@@ -47,7 +47,7 @@ describe ListController do
     qa = topics.find { |t| t["id"] == qa_topic.id }
     non_qa = topics.find { |t| t["id"] == topic.id }
 
-    expect(qa["qa_enabled"]).to eq(nil)
-    expect(non_qa["qa_enabled"]).to eq(nil)
+    expect(qa["is_qa"]).to eq(nil)
+    expect(non_qa["is_qa"]).to eq(nil)
   end
 end

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -28,8 +28,8 @@ describe ListController do
     qa = topics.find { |t| t["id"] == qa_topic.id }
     non_qa = topics.find { |t| t["id"] == topic.id }
 
-    expect(qa["last_read_post_number"]).to eq(nil)
-    expect(non_qa["last_read_post_number"]).to eq(2)
+    expect(qa["qa_enabled"]).to eq(true)
+    expect(non_qa["qa_enabled"]).to eq(nil)
   end
 
   it 'should return the right attributes when Q&A is disabled' do
@@ -47,7 +47,7 @@ describe ListController do
     qa = topics.find { |t| t["id"] == qa_topic.id }
     non_qa = topics.find { |t| t["id"] == topic.id }
 
-    expect(qa["last_read_post_number"]).to eq(2)
+    expect(qa["qa_enabled"]).to eq(nil)
     expect(non_qa["qa_enabled"]).to eq(nil)
   end
 end

--- a/test/javascripts/acceptance/question-answer-test.js
+++ b/test/javascripts/acceptance/question-answer-test.js
@@ -96,17 +96,17 @@ function qaEnabledTopicResponse() {
 
 function qaTopicListResponse() {
   // will link to OP
-  topicList.topic_list.topics[0].qa_enabled = true;
+  topicList.topic_list.topics[0].is_qa = true;
   topicList.topic_list.topics[0].last_read_post_number =
     topicList.topic_list.topics[0].highest_post_number;
 
   // will sort by activity
-  topicList.topic_list.topics[1].qa_enabled = true;
+  topicList.topic_list.topics[1].is_qa = true;
   topicList.topic_list.topics[1].last_read_post_number =
     topicList.topic_list.topics[1].highest_post_number - 2;
 
   // will link to last post
-  topicList.topic_list.topics[3].qa_enabled = true;
+  topicList.topic_list.topics[3].is_qa = true;
   topicList.topic_list.topics[3].last_read_post_number =
     topicList.topic_list.topics[3].highest_post_number - 1;
 

--- a/test/javascripts/acceptance/question-answer-test.js
+++ b/test/javascripts/acceptance/question-answer-test.js
@@ -9,10 +9,12 @@ import {
 } from "discourse/tests/helpers/qunit-helpers";
 import { skip, test } from "qunit";
 import topicFixtures from "discourse/tests/fixtures/topic";
+import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 import { cloneJSON } from "discourse-common/lib/object";
 import I18n from "I18n";
 
 const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
+const topicList = cloneJSON(discoveryFixtures["/latest.json"]);
 
 function qaEnabledTopicResponse() {
   topicResponse.post_stream.posts[0]["qa_vote_count"] = 0;
@@ -92,6 +94,25 @@ function qaEnabledTopicResponse() {
   return topicResponse;
 }
 
+function qaTopicListResponse() {
+  // will link to OP
+  topicList.topic_list.topics[0].qa_enabled = true;
+  topicList.topic_list.topics[0].last_read_post_number =
+    topicList.topic_list.topics[0].highest_post_number;
+
+  // will sort by activity
+  topicList.topic_list.topics[1].qa_enabled = true;
+  topicList.topic_list.topics[1].last_read_post_number =
+    topicList.topic_list.topics[1].highest_post_number - 2;
+
+  // will link to last post
+  topicList.topic_list.topics[3].qa_enabled = true;
+  topicList.topic_list.topics[3].last_read_post_number =
+    topicList.topic_list.topics[3].highest_post_number - 1;
+
+  return topicList;
+}
+
 let filteredByActivity = false;
 
 function setupQA(needs) {
@@ -169,6 +190,10 @@ function setupQA(needs) {
 
     server.delete("/qa/vote/comment", () => {
       return helper.response({});
+    });
+
+    server.get("/latest.json", () => {
+      return helper.response(qaTopicListResponse());
     });
   });
 }
@@ -507,6 +532,25 @@ acceptance("Discourse Question Answer - logged in user", function (needs) {
       !exists("#post_2 .qa-comment-2 .qa-comment-actions-vote-count"),
       "updates the comment vote count correctly"
     );
+  });
+
+  test("topic list link overrides work", async function (assert) {
+    await visit("/");
+
+    const firstTopicLink = query(
+      ".topic-list-item:first-child .raw-topic-link"
+    ).getAttribute("href");
+    assert.ok(firstTopicLink.endsWith("/1"));
+
+    const secondTopicLink = query(
+      ".topic-list-item:nth-child(2) .raw-topic-link"
+    ).getAttribute("href");
+    assert.ok(secondTopicLink.endsWith("?filter=activity"));
+
+    const fourthTopicLink = query(
+      ".topic-list-item:nth-child(4) .raw-topic-link"
+    ).getAttribute("href");
+    assert.ok(fourthTopicLink.endsWith("/2"));
   });
 
   // Skip message bus tests but keep it around for development use. We currently do not have a reliable way to wait for


### PR DESCRIPTION
Per some internal discussions, this adds some logic for linking when there are unread posts in a Q&A topic. 

- when user has no unread posts, link to OP (unchanged, but logic moved to JS code)
- when user has one unread post, link to it
- when user has 2+ unread posts, link to first unread post and switch to sorting by activity

Sadly, I don't think we can easily add a useful test here. It would need to rely entirely on fixtures, which isn't ideal. 