### PR TITLE
DEV: No need to set `enable_filtered_replies_view`

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -196,6 +196,4 @@ after_initialize do
     topic_view.posts_voted_on =
       QuestionAnswerVote.where(votable_type: 'Post', votable_id: post_ids).distinct.pluck(:votable_id)
   end
-
-  SiteSetting.enable_filtered_replies_view = true
 end


### PR DESCRIPTION
From what I can tell, this is not needed in the current implementation. (And it will enable the setting globally, not just for Q&A topics, which admins might find undesirable.) 