### PR TITLE
FEATURE: Set topic as Q&A formatted using Topic#subtype.

### DIFF
--- a/app/controllers/question_answer/comments_controller.rb
+++ b/app/controllers/question_answer/comments_controller.rb
@@ -88,7 +88,7 @@ module QuestionAnswer
     end
 
     def ensure_qa_enabled
-      raise Discourse::InvalidAccess if !@post.qa_enabled
+      raise Discourse::InvalidAccess if !@post.is_qa_topic?
     end
   end
 end

--- a/app/controllers/question_answer/votes_controller.rb
+++ b/app/controllers/question_answer/votes_controller.rb
@@ -126,7 +126,7 @@ module QuestionAnswer
     end
 
     def ensure_qa_enabled
-      raise Discourse::InvalidAccess.new unless Topic.qa_enabled(@post.topic)
+      raise Discourse::InvalidAccess.new unless @post.is_qa_topic?
     end
 
     def find_comment

--- a/app/models/question_answer_comment.rb
+++ b/app/models/question_answer_comment.rb
@@ -45,7 +45,7 @@ class QuestionAnswerComment < ActiveRecord::Base
   end
 
   def ensure_can_comment
-    if !post.qa_enabled
+    if !post.is_qa_topic?
       errors.add(:base, I18n.t("qa.comment.errors.qa_not_enabled"))
     elsif post.reply_to_post_number.present?
       errors.add(:base, I18n.t("qa.comment.errors.not_permitted"))

--- a/app/models/question_answer_vote.rb
+++ b/app/models/question_answer_vote.rb
@@ -39,7 +39,7 @@ class QuestionAnswerVote < ActiveRecord::Base
       errors.add(:base, I18n.t("post.qa.errors.comment_cannot_be_downvoted"))
     end
 
-    if !comment.post.qa_enabled
+    if !comment.post.is_qa_topic?
       errors.add(:base, I18n.t("post.qa.errors.qa_not_enabled"))
     end
   end
@@ -47,7 +47,7 @@ class QuestionAnswerVote < ActiveRecord::Base
   def ensure_valid_post
     post = votable
 
-    if !post.qa_enabled
+    if !post.is_qa_topic?
       errors.add(:base, I18n.t("post.qa.errors.qa_not_enabled"))
     elsif post.reply_to_post_number.present?
       errors.add(:base, I18n.t("post.qa.errors.voting_not_permitted"))

--- a/assets/javascripts/discourse/connectors/topic-title/add-qa-topic-page-class.hbs
+++ b/assets/javascripts/discourse/connectors/topic-title/add-qa-topic-page-class.hbs
@@ -1,3 +1,3 @@
-{{#if model.postStream.qa_enabled}}
+{{#if model.is_qa}}
   {{qa-topic-page-class topic=model}}
 {{/if}}

--- a/assets/javascripts/discourse/initializers/extend-composer-actions.js
+++ b/assets/javascripts/discourse/initializers/extend-composer-actions.js
@@ -1,0 +1,68 @@
+import I18n from "I18n";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { CREATE_TOPIC } from "discourse/models/composer";
+
+export default {
+  name: "extend-composer-actions",
+  initialize(container) {
+    const siteSettings = container.lookup("site-settings:main");
+
+    if (!siteSettings.qa_enabled) {
+      return;
+    }
+
+    withPluginApi("0.13.0", (api) => {
+      api.serializeOnCreate("create_as_qa", "createAsQA");
+
+      api.customizeComposerText({
+        actionTitle(model) {
+          return model.createAsQA ? I18n.t("composer.create_qa.label") : null;
+        },
+
+        saveLabel(model) {
+          return model.createAsQA ? "composer.create_qa.label" : null;
+        },
+      });
+
+      api.modifyClass("component:composer-actions", {
+        pluginId: "discourse-question-answer",
+
+        toggleQASelected(options, model) {
+          model.toggleProperty("createAsQA");
+          model.notifyPropertyChange("replyOptions");
+          model.notifyPropertyChange("action");
+        },
+      });
+
+      api.modifySelectKit("composer-actions").appendContent((options) => {
+        if (options.action === CREATE_TOPIC) {
+          if (options.composerModel.createAsQA) {
+            return [
+              {
+                name: I18n.t("composer.composer_actions.remove_as_qa.label"),
+                description: I18n.t(
+                  "composer.composer_actions.remove_as_qa.desc"
+                ),
+                icon: "plus",
+                id: "toggleQA",
+              },
+            ];
+          } else {
+            return [
+              {
+                name: I18n.t("composer.composer_actions.create_as_qa.label"),
+                description: I18n.t(
+                  "composer.composer_actions.create_as_qa.desc"
+                ),
+                icon: "plus",
+                id: "toggleQA",
+              },
+            ];
+          }
+        } else {
+          return [];
+        }
+      });
+    });
+  },
+};

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,16 @@
 en:
   js:
+    composer:
+      create_qa:
+        label: "Create Q&A topic"
+      composer_actions:
+        create_as_qa:
+          label: "Toggle Q&A"
+          desc: "Topic will be created in the Question & Answer format"
+        remove_as_qa:
+          label: "Remove Q&A"
+          desc: "Topic will be created in the regular format"
+
     post:
       actions:
         undo:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,15 +3,20 @@ en:
     qa:
       errors:
         replying_to_post_not_permited: "You are not allowed to create a post in reply to another post."
-        qa_not_enabled: "QnA is not enabled."
         voting_not_permitted: "You are not allowed to vote on this post."
         comment_cannot_be_downvoted: "You can only upvote comments."
+  topic:
+    qa:
+      errors:
+        qa_not_enabled: "Q&A is not enabled."
+        subtype_not_allowed: "Q&A formatted topics can only be created on regular topics."
+        cannot_change_to_qa_subtype: "Changing a topic's subtype to Q&A is not permitted."
 
   site_settings:
-    qa_tags: "Tags to enable QnA on topic"
-    qa_enabled: "Enable QnA Plugin"
-    qa_disable_like_on_answers: "Disables like button on answers in QnA topics"
-    qa_undo_vote_action_window: "Number of minutes users are allowed to undo votes in QnA topics (enter 0 for no limit)"
+    qa_tags: "Tags to enable Q&A on topic"
+    qa_enabled: "Enable Q&A Plugin"
+    qa_disable_like_on_answers: "Disables like button on answers in Q&A topics"
+    qa_undo_vote_action_window: "Number of minutes users are allowed to undo votes in Q&A topics (enter 0 for no limit)"
     qa_comment_limit_per_post: "Number of comments allowed on each question or answer"
 
   post_action_types:
@@ -33,6 +38,6 @@ en:
   qa:
     comment:
       errors:
-        qa_not_enabled: "QnA is not enabled."
+        qa_not_enabled: "Commenting on a post that is not in a Q&A formatted topic is not permitted"
         not_permitted: "Commenting on associated post is not permitted."
         limit_exceeded: "Limit of %{limit} comments per post has been reached."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,8 +1,4 @@
 plugins:
-  qa_tags:
-    client: true
-    type: list
-    default: 'question'
   qa_enabled:
     client: true
     default: true

--- a/extensions/post_extension.rb
+++ b/extensions/post_extension.rb
@@ -10,8 +10,8 @@ module QuestionAnswer
       base.validate :ensure_only_answer
     end
 
-    def qa_enabled
-      ::Topic.qa_enabled(topic)
+    def is_qa_topic?
+      topic.is_qa?
     end
 
     def qa_last_voted(user_id)
@@ -39,7 +39,7 @@ module QuestionAnswer
       if will_save_change_to_reply_to_post_number? &&
           reply_to_post_number &&
           reply_to_post_number != 1 &&
-          qa_enabled
+          is_qa_topic?
 
         errors.add(:base, I18n.t("post.qa.errors.replying_to_post_not_permited"))
       end

--- a/extensions/post_serializer_extension.rb
+++ b/extensions/post_serializer_extension.rb
@@ -5,7 +5,6 @@ module QuestionAnswer
     def self.included(base)
       base.attributes(
         :qa_vote_count,
-        :qa_enabled,
         :qa_user_voted_direction,
         :qa_has_votes,
         :comments,
@@ -18,7 +17,7 @@ module QuestionAnswer
     end
 
     def include_qa_vote_count?
-      qa_enabled
+      object.is_qa_topic?
     end
 
     def comments
@@ -30,7 +29,7 @@ module QuestionAnswer
     end
 
     def include_comments?
-      @topic_view && qa_enabled
+      @topic_view && object.is_qa_topic?
     end
 
     def comments_count
@@ -38,7 +37,7 @@ module QuestionAnswer
     end
 
     def include_comments_count?
-      @topic_view && qa_enabled
+      @topic_view && object.is_qa_topic?
     end
 
     def qa_user_voted_direction
@@ -46,7 +45,7 @@ module QuestionAnswer
     end
 
     def include_qa_user_voted_direction?
-      @topic_view && qa_enabled && @topic_view.posts_user_voted.present?
+      @topic_view && object.is_qa_topic? && @topic_view.posts_user_voted.present?
     end
 
     def qa_has_votes
@@ -54,17 +53,7 @@ module QuestionAnswer
     end
 
     def include_qa_has_votes?
-      @topic_view && qa_enabled
-    end
-
-    def qa_disable_like
-      return true if SiteSetting.qa_disable_like_on_answers
-    end
-
-    alias_method :include_qa_disable_like?, :include_comments?
-
-    def qa_enabled
-      @topic_view ? @topic_view.qa_enabled : object.qa_enabled
+      @topic_view && object.is_qa_topic?
     end
 
     private

--- a/extensions/topic_extension.rb
+++ b/extensions/topic_extension.rb
@@ -4,12 +4,16 @@ module QuestionAnswer
   module TopicExtension
     def self.included(base)
       base.extend(ClassMethods)
+      base.validate :ensure_regular_topic, on: [:create]
+      base.validate :ensure_no_qa_subtype, on: [:update]
+      base.const_set :QA_SUBTYPE, 'question_answer'
     end
 
     def reload(options = nil)
       @answers = nil
       @comments = nil
       @last_answerer = nil
+      @is_qa = nil
       super(options)
     end
 
@@ -60,6 +64,10 @@ module QuestionAnswer
       Topic.qa_enabled(self)
     end
 
+    def is_qa?
+      @is_qa ||= SiteSetting.qa_enabled && self.subtype == Topic::QA_SUBTYPE
+    end
+
     # class methods
     module ClassMethods
       # rename to something like qa_user_votes?
@@ -81,6 +89,24 @@ module QuestionAnswer
 
         tags = topic.tags.map(&:name)
         !(tags & SiteSetting.qa_tags.split('|')).empty?
+      end
+    end
+
+    private
+
+    def ensure_no_qa_subtype
+      if will_save_change_to_subtype? && self.subtype == Topic::QA_SUBTYPE
+        self.errors.add(:base, I18n.t("topic.qa.errors.cannot_change_to_qa_subtype"))
+      end
+    end
+
+    def ensure_regular_topic
+      return if self.subtype != Topic::QA_SUBTYPE
+
+      if !SiteSetting.qa_enabled
+        self.errors.add(:base, I18n.t("topic.qa.errors.qa_not_enabled"))
+      elsif self.archetype != Archetype.default
+        self.errors.add(:base, I18n.t("topic.qa.errors.subtype_not_allowed"))
       end
     end
   end

--- a/extensions/topic_extension.rb
+++ b/extensions/topic_extension.rb
@@ -60,10 +60,6 @@ module QuestionAnswer
       @last_answerer ||= User.find(answers.last[:user_id])
     end
 
-    def qa_enabled
-      Topic.qa_enabled(self)
-    end
-
     def is_qa?
       @is_qa ||= SiteSetting.qa_enabled && self.subtype == Topic::QA_SUBTYPE
     end
@@ -80,15 +76,6 @@ module QuestionAnswer
           .joins("INNER JOIN posts ON posts.id = question_answer_votes.votable_id")
           .where(user: user, votable_type: 'Post')
           .where("posts.topic_id = ?", topic.id)
-      end
-
-      def qa_enabled(topic)
-        return false unless SiteSetting.qa_enabled
-        return false if !topic
-        return false if topic.category && topic.category.topic_id == topic.id
-
-        tags = topic.tags.map(&:name)
-        !(tags & SiteSetting.qa_tags.split('|')).empty?
       end
     end
 

--- a/extensions/topic_list_item_serializer_extension.rb
+++ b/extensions/topic_list_item_serializer_extension.rb
@@ -5,22 +5,16 @@ module QuestionAnswer
     # For Q&A topics, we always want to link to the first post because timeline
     # ordering is not consistent with last unread.
     def last_read_post_number
-      return nil if qa_enabled?
+      return nil if object.is_qa?
       super
     end
 
     def include_last_read_post_number?
-      if qa_enabled?
+      if object.is_qa?
         true
       else
         super
       end
-    end
-
-    private
-
-    def qa_enabled?
-      @qa_enabled ||= object.qa_enabled
     end
   end
 end

--- a/extensions/topic_view_serializer_extension.rb
+++ b/extensions/topic_view_serializer_extension.rb
@@ -4,7 +4,7 @@ module QuestionAnswer
   module TopicViewSerializerExtension
     def self.included(base)
       base.attributes(
-        :qa_enabled,
+        :is_qa,
         :last_answered_at,
         :last_commented_on,
         :answer_count,
@@ -13,12 +13,12 @@ module QuestionAnswer
       )
     end
 
-    def qa_enabled
-      object.qa_enabled
+    def is_qa
+      true
     end
 
-    def include_qa_enabled?
-      object.qa_enabled
+    def include_is_qa?
+      object.topic.is_qa?
     end
 
     def last_answered_at
@@ -26,7 +26,7 @@ module QuestionAnswer
     end
 
     def include_last_answered_at?
-      qa_enabled
+      object.topic.is_qa?
     end
 
     def last_commented_on
@@ -34,7 +34,7 @@ module QuestionAnswer
     end
 
     def include_last_commented_on?
-      qa_enabled
+      object.topic.is_qa?
     end
 
     def answer_count
@@ -42,7 +42,7 @@ module QuestionAnswer
     end
 
     def include_answer_count?
-      qa_enabled
+      object.topic.is_qa?
     end
 
     def last_answer_post_number
@@ -50,7 +50,7 @@ module QuestionAnswer
     end
 
     def include_last_answer_post_number?
-      qa_enabled
+      object.topic.is_qa?
     end
 
     def last_answerer
@@ -62,7 +62,7 @@ module QuestionAnswer
     end
 
     def include_last_answerer?
-      qa_enabled
+      object.topic.is_qa?
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -87,12 +87,6 @@ after_initialize do
     object.vote_count
   end
 
-  add_to_class(:topic_view, :qa_enabled) do
-    return @qa_enabled if defined?(@qa_enabled)
-
-    @qa_enabled = @topic.qa_enabled
-  end
-
   add_to_class(:topic_view, :user_voted_posts) do |user|
     @user_voted_posts ||= {}
 
@@ -113,7 +107,7 @@ after_initialize do
   end
 
   TopicView.apply_custom_default_scope do |scope, topic_view|
-    if topic_view.topic.qa_enabled &&
+    if topic_view.topic.is_qa? &&
       !topic_view.instance_variable_get(:@replies_to_post_number) &&
       !topic_view.instance_variable_get(:@post_ids)
 
@@ -135,7 +129,7 @@ after_initialize do
   end
 
   TopicView.on_preload do |topic_view|
-    next if !topic_view.qa_enabled
+    next if !topic_view.topic.is_qa?
 
     topic_view.comments = {}
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -196,4 +196,21 @@ after_initialize do
     topic_view.posts_voted_on =
       QuestionAnswerVote.where(votable_type: 'Post', votable_id: post_ids).distinct.pluck(:votable_id)
   end
+
+  add_permitted_post_create_param(:create_as_qa)
+
+  # TODO: Core should be exposing the following as proper plugin interfaces.
+  NewPostManager.add_plugin_payload_attribute(:subtype)
+  TopicSubtype.register(Topic::QA_SUBTYPE)
+
+  NewPostManager.add_handler do |manager|
+    if !manager.args[:topic_id] &&
+      manager.args[:create_as_qa] == 'true' &&
+      (manager.args[:archetype].blank? || manager.args[:archetype] == Archetype.default)
+
+      manager.args[:subtype] = Topic::QA_SUBTYPE
+    end
+
+    false
+  end
 end

--- a/spec/components/question_answer/vote_manager_spec.rb
+++ b/spec/components/question_answer/vote_manager_spec.rb
@@ -6,15 +6,14 @@ describe QuestionAnswer::VoteManager do
   fab!(:user)  { Fabricate(:user) }
   fab!(:user_2)  { Fabricate(:user) }
   fab!(:user_3)  { Fabricate(:user) }
-  fab!(:post)  { Fabricate(:post, post_number: 2) }
-  fab!(:tag)  { Fabricate(:tag) }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
+  fab!(:topic_post) { Fabricate(:post, topic: topic) }
+  fab!(:post)  { Fabricate(:post, topic: topic) }
   fab!(:up) { QuestionAnswerVote.directions[:up] }
   fab!(:down) { QuestionAnswerVote.directions[:down] }
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
-    post.topic.tags << tag
   end
 
   describe '.vote' do

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -3,9 +3,8 @@
 require 'rails_helper'
 
 describe TopicView do
-  fab!(:tag) { Fabricate(:tag) }
   fab!(:user) { Fabricate(:user) }
-  fab!(:topic) { Fabricate(:topic).tap { |t| t.tags << tag } }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
   fab!(:post) { create_post(topic: topic) }
 
   fab!(:answer) { create_post(topic: topic) }
@@ -25,7 +24,6 @@ describe TopicView do
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
     vote
     vote_2
     comment

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -6,15 +6,14 @@ describe Post do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
   fab!(:user3) { Fabricate(:user) }
-  fab!(:post) { Fabricate(:post, post_number: 2) }
-  fab!(:tag) { Fabricate(:tag, name: 'qa') }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
+  fab!(:topic_post) { Fabricate(:post, topic: topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
   let(:up) { QuestionAnswerVote.directions[:up] }
   let(:users) { [user1, user2, user3] }
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
-    post.topic.tags << tag
   end
 
   context "validation" do

--- a/spec/models/question_answer_vote_spec.rb
+++ b/spec/models/question_answer_vote_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 describe QuestionAnswerVote do
-  fab!(:post) { Fabricate(:post, reply_to_post_number: nil, post_number: 2) }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
+  fab!(:topic_post) { Fabricate(:post, topic: topic) }
+  fab!(:post) { Fabricate(:post, topic: topic) }
   fab!(:user) { Fabricate(:user) }
   fab!(:tag) { Fabricate(:tag) }
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
-    post.topic.tags << tag
   end
 
   context 'validations' do
@@ -48,10 +48,11 @@ describe QuestionAnswerVote do
     end
 
     context 'comments' do
-      let!(:qa_comment) { Fabricate(:qa_comment, post: post) }
+      fab!(:qa_comment) { Fabricate(:qa_comment, post: post) }
 
       it 'ensures vote cannot be created on a comment when QnA is disabled' do
         SiteSetting.qa_enabled = false
+        qa_comment.reload
 
         qa_vote = QuestionAnswerVote.new(votable: qa_comment, user: user, direction: QuestionAnswerVote.directions[:up])
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 describe Topic do
   fab!(:user) { Fabricate(:user) }
   fab!(:category) { Fabricate(:category) }
-  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:topic) { Fabricate(:topic, category: category, subtype: Topic::QA_SUBTYPE) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
 
   fab!(:answers) do
     5.times.map { Fabricate(:post, topic: topic) }.sort_by(&:created_at)
   end
 
-  let(:comments) do
+  fab!(:comments) do
     answer = answers.first
 
     5.times.map do
@@ -20,15 +20,39 @@ describe Topic do
     end.sort_by(&:created_at)
   end
 
-  fab!(:tag) { Fabricate(:tag) }
-
-  before do
-    SiteSetting.qa_tags = tag.name
-    topic.tags << tag
-    comments
-  end
-
   let(:up) { QuestionAnswerVote.directions[:up] }
+
+  context "validations" do
+    describe '#subtype' do
+      it "should not allow Q&A formated topics to be created when qa_enabled site setting is not enabled" do
+        SiteSetting.qa_enabled = false
+
+        topic = Fabricate.build(:topic, archetype: Archetype.default, subtype: Topic::QA_SUBTYPE)
+
+        expect(topic.valid?).to eq(false)
+        expect(topic.errors.full_messages).to eq([I18n.t("topic.qa.errors.qa_not_enabled")])
+      end
+
+      it "should not allow topic to change to Q&A subtype once it has been created" do
+        topic_2 = Fabricate(:topic)
+        topic_2.subtype = Topic::QA_SUBTYPE
+
+        expect(topic_2.valid?).to eq(false)
+        expect(topic_2.errors.full_messages).to eq([I18n.t("topic.qa.errors.cannot_change_to_qa_subtype")])
+      end
+
+      it "should only allow Q&A subtype to be set on regular topics" do
+        topic = Fabricate.build(:topic, archetype: Archetype.default, subtype: Topic::QA_SUBTYPE)
+
+        expect(topic.valid?).to eq(true)
+
+        topic.archetype = Archetype.private_message
+
+        expect(topic.valid?).to eq(false)
+        expect(topic.errors.full_messages).to eq([I18n.t("topic.qa.errors.subtype_not_allowed")])
+      end
+    end
+  end
 
   it 'should return correct comments' do
     comment_ids = comments.map(&:id)
@@ -92,28 +116,6 @@ describe Topic do
 
       expect(Topic.qa_votes(topic, user).pluck(:votable_id))
         .to contain_exactly(*expected)
-    end
-  end
-
-  describe '.qa_enabled' do
-    it 'should return false if topic is blank' do
-      expect(Topic.qa_enabled(nil)).to eq(false)
-    end
-
-    it 'should return false for a PM' do
-      expect(Topic.qa_enabled(Fabricate(:private_message_topic))).to eq(false)
-    end
-
-    it 'should return false if disabled' do
-      SiteSetting.qa_enabled = false
-
-      expect(Topic.qa_enabled(topic)).to eq(false)
-    end
-
-    it 'should return false if category topic' do
-      category.update!(topic_id: topic.id)
-
-      expect(Topic.qa_enabled(topic)).to eq(false)
     end
   end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -24,7 +24,7 @@ describe Topic do
 
   context "validations" do
     describe '#subtype' do
-      it "should not allow Q&A formated topics to be created when qa_enabled site setting is not enabled" do
+      it "should not allow Q&A formatted topics to be created when qa_enabled site setting is not enabled" do
         SiteSetting.qa_enabled = false
 
         topic = Fabricate.build(:topic, archetype: Archetype.default, subtype: Topic::QA_SUBTYPE)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -5,21 +5,13 @@ require 'rails_helper'
 describe ListController do
   fab!(:user) { Fabricate(:user) }
   fab!(:category) { Fabricate(:category) }
-  fab!(:tag) { Fabricate(:tag) }
-
-  fab!(:qa_topic) do
-    Fabricate(:topic, category: category).tap do |t|
-      t.tags << tag
-    end
-  end
-
+  fab!(:qa_topic) { Fabricate(:topic, category: category, subtype: Topic::QA_SUBTYPE) }
   fab!(:qa_topic_post) { Fabricate(:post, topic: qa_topic) }
   fab!(:qa_topic_answer) { create_post(topic: qa_topic, reply_to_post: nil) }
   fab!(:topic) { Fabricate(:topic) }
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
     sign_in(user)
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe PostsController do
+  fab!(:user) { Fabricate(:user) }
+
+  describe '#create' do
+    before do
+      sign_in(user)
+      SiteSetting.qa_enabled = true
+    end
+
+    it "creates a topic with the right subtype when create_as_qa param is provided" do
+      post "/posts.json", params: {
+        raw: 'this is some raw',
+        title: 'this is some title',
+        create_as_qa: true,
+      }
+
+      expect(response.status).to eq(200)
+
+      topic = Topic.last
+
+      expect(topic.is_qa?).to eq(true)
+    end
+
+    it "ignores create_as_qa param when trying to create private message" do
+      post "/posts.json", params: {
+        raw: 'this is some raw',
+        title: 'this is some title',
+        create_as_qa: true,
+        archetype: Archetype.private_message,
+        target_recipients: user.username
+      }
+
+      expect(response.status).to eq(200)
+
+      topic = Topic.last
+
+      expect(topic.is_qa?).to eq(false)
+    end
+  end
+end

--- a/spec/requests/question_answer/comments_controller_spec.rb
+++ b/spec/requests/question_answer/comments_controller_spec.rb
@@ -5,16 +5,9 @@ require 'rails_helper'
 RSpec.describe QuestionAnswer::CommentsController do
   fab!(:user) { Fabricate(:user) }
   fab!(:admin) { Fabricate(:admin) }
-  fab!(:category) { Fabricate(:category) }
-  fab!(:tag) { Fabricate(:tag) }
   fab!(:group) { Fabricate(:group) }
-
-  fab!(:topic) do
-    Fabricate(:topic, category: category).tap do |t|
-      t.tags << tag
-    end
-  end
-
+  fab!(:category) { Fabricate(:category) }
+  fab!(:topic) { Fabricate(:topic, category: category, subtype: Topic::QA_SUBTYPE) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
   fab!(:answer) { Fabricate(:post, topic: topic) }
   let(:comment) { Fabricate(:qa_comment, post: answer) }
@@ -23,23 +16,12 @@ RSpec.describe QuestionAnswer::CommentsController do
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
     comment
     comment_2
     comment_3
   end
 
   describe '#load_comments' do
-    it 'returns the right response when QnA is not enabled' do
-      SiteSetting.qa_enabled = false
-
-      get "/qa/comments.json", params: {
-        post_id: answer.id, last_comment_id: comment.id
-      }
-
-      expect(response.status).to eq(403)
-    end
-
     it 'returns the right response when user is not allowed to view post' do
       category.update!(read_restricted: true)
 
@@ -85,17 +67,6 @@ RSpec.describe QuestionAnswer::CommentsController do
   describe '#create' do
     before do
       sign_in(user)
-    end
-
-    it 'returns the right response when Q&A is not enabled' do
-      SiteSetting.qa_enabled = false
-
-      post "/qa/comments.json", params: {
-        post_id: answer.id,
-        raw: "this is some comment"
-      }
-
-      expect(response.status).to eq(403)
     end
 
     it 'returns the right response when user is not allowed to create post' do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1,28 +1,24 @@
 # frozen_string_literal: true
 
 describe TopicsController do
-  fab!(:tag) { Fabricate(:tag) }
   fab!(:user) { Fabricate(:user) }
-  fab!(:topic) { Fabricate(:topic).tap { |t| t.tags << tag } }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
   fab!(:post) { create_post(topic: topic) }
 
   fab!(:answer) { create_post(topic: topic) }
   fab!(:answer_2) { create_post(topic: topic) }
   fab!(:answer_3) { create_post(topic: topic) }
 
-  let(:vote) do
+  fab!(:vote) do
     QuestionAnswer::VoteManager.vote(answer_2, user, direction: QuestionAnswerVote.directions[:up])
   end
 
-  let(:vote_2) do
+  fab!(:vote_2) do
     QuestionAnswer::VoteManager.vote(answer, user, direction: QuestionAnswerVote.directions[:down])
   end
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
-    vote
-    vote_2
   end
 
   describe '#show' do

--- a/spec/serializers/question_answer/comment_serializer_spec.rb
+++ b/spec/serializers/question_answer/comment_serializer_spec.rb
@@ -3,16 +3,13 @@
 require 'rails_helper'
 
 describe QuestionAnswerCommentSerializer do
-  fab!(:tag) { Fabricate(:tag) }
-  fab!(:topic) { Fabricate(:topic, tags: [tag]) }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
   fab!(:post) { Fabricate(:post, topic: topic) }
   fab!(:user) { Fabricate(:user) }
-  let(:qa_comment) { Fabricate(:qa_comment, post: post) }
+  fab!(:qa_comment) { Fabricate(:qa_comment, post: post) }
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
-
     QuestionAnswer::VoteManager.vote(qa_comment, post.user)
   end
 

--- a/spec/serializers/question_answer/post_serializer_spec.rb
+++ b/spec/serializers/question_answer/post_serializer_spec.rb
@@ -4,17 +4,10 @@ require 'rails_helper'
 
 describe QuestionAnswer::PostSerializerExtension do
   fab!(:user) { Fabricate(:user) }
-  fab!(:tag) { Fabricate(:tag) }
-
-  fab!(:topic) do
-    Fabricate(:topic).tap do |t|
-      t.tags << tag
-    end
-  end
-
-  fab!(:post) { Fabricate(:post, topic: topic, post_number: 1) }
-  fab!(:answer) { Fabricate(:post, topic: topic, post_number: 2) }
-  let(:comment) { Fabricate(:qa_comment, post: answer) }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
+  fab!(:topic_post) { Fabricate(:post, topic: topic) }
+  fab!(:answer) { Fabricate(:post, topic: topic) }
+  fab!(:comment) { Fabricate(:qa_comment, post: answer) }
   let(:topic_view) { TopicView.new(topic, user) }
   let(:up) { QuestionAnswerVote.directions[:up] }
   let(:guardian) { Guardian.new(user) }
@@ -28,8 +21,6 @@ describe QuestionAnswer::PostSerializerExtension do
   context 'qa enabled' do
     before do
       SiteSetting.qa_enabled = true
-      SiteSetting.qa_tags = tag.name
-      comment
     end
 
     it 'should return the right attributes' do
@@ -37,19 +28,21 @@ describe QuestionAnswer::PostSerializerExtension do
 
       expect(serialized[:qa_vote_count]).to eq(1)
       expect(serialized[:qa_user_voted_direction]).to eq(up)
-      expect(serialized[:qa_enabled]).to eq(true)
       expect(serialized[:comments_count]).to eq(1)
       expect(serialized[:comments].first[:id]).to eq(comment.id)
     end
   end
 
   context 'qa disabled' do
+    before do
+      SiteSetting.qa_enabled = false
+    end
+
     it 'should not include dependent_keys' do
       expect(serialized[:qa_vote_count]).to eq(nil)
       expect(serialized[:qa_user_voted_direction]).to eq(nil)
       expect(serialized[:comments_count]).to eq(nil)
       expect(serialized[:comments]).to eq(nil)
-      expect(serialized[:qa_enabled]).to eq(false)
     end
   end
 end

--- a/spec/serializers/question_answer/topic_view_serializer_spec.rb
+++ b/spec/serializers/question_answer/topic_view_serializer_spec.rb
@@ -3,25 +3,16 @@
 require 'rails_helper'
 
 describe QuestionAnswer::TopicViewSerializerExtension do
-  fab!(:tag) { Fabricate(:tag) }
-
-  fab!(:topic) do
-    Fabricate(:topic).tap do |t|
-      t.tags << tag
-    end
-  end
-
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
   fab!(:answer) { Fabricate(:post, topic: topic, reply_to_post_number: nil) }
-  let(:comment) { Fabricate(:qa_comment, post: answer) }
+  fab!(:comment) { Fabricate(:qa_comment, post: answer) }
   fab!(:user) { Fabricate(:user) }
   fab!(:guardian) { Guardian.new(user) }
   let(:topic_view) { TopicView.new(topic, user) }
 
   before do
     SiteSetting.qa_enabled = true
-    SiteSetting.qa_tags = tag.name
-    comment
   end
 
   it 'should return correct values' do
@@ -32,7 +23,6 @@ describe QuestionAnswer::TopicViewSerializerExtension do
 
     payload = TopicViewSerializer.new(topic_view, scope: guardian, root: false).as_json
 
-    expect(payload[:qa_enabled]).to eq(true)
     expect(payload[:last_answered_at]).to eq(answer.created_at)
     expect(payload[:last_commented_on]).to eq(comment.created_at)
     expect(payload[:answer_count]).to eq(1)

--- a/test/javascripts/acceptance/composer-test.js
+++ b/test/javascripts/acceptance/composer-test.js
@@ -1,0 +1,79 @@
+import { click, fillIn, visit } from "@ember/test-helpers";
+import { acceptance, query } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { test } from "qunit";
+import I18n from "I18n";
+import { parsePostData } from "discourse/tests/helpers/create-pretender";
+
+let createAsQASetInRequest = false;
+
+acceptance("Discourse Question Answer - composer", function (needs) {
+  needs.user();
+  needs.settings({ qa_enabled: true });
+
+  needs.hooks.afterEach(() => {
+    createAsQASetInRequest = false;
+  });
+
+  needs.pretender((server, helper) => {
+    server.post("/posts", (request) => {
+      if (parsePostData(request.requestBody).create_as_qa === "true") {
+        createAsQASetInRequest = true;
+      }
+
+      return helper.response({
+        post: {
+          topic_id: 280,
+        },
+      });
+    });
+  });
+
+  test("Creating new topic with Q&A format", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+
+    const composerActionTitle = selectKit(".composer-action-title");
+    await composerActionTitle.expand();
+    await composerActionTitle.selectKitSelectRowByName(
+      I18n.t("composer.composer_actions.create_as_qa.label")
+    );
+
+    assert.strictEqual(
+      query(".action-title").textContent.trim(),
+      I18n.t("composer.create_qa.label"),
+      "displays the right composer action title when creating Q&A topic"
+    );
+
+    assert.strictEqual(
+      query(".create .d-button-label").textContent.trim(),
+      I18n.t("composer.create_qa.label"),
+      "displays the right label for composer create button"
+    );
+
+    await composerActionTitle.expand();
+    await composerActionTitle.selectKitSelectRowByName(
+      I18n.t("composer.composer_actions.remove_as_qa.label")
+    );
+
+    assert.notStrictEqual(
+      query(".action-title").textContent.trim(),
+      I18n.t("composer.create_qa.label"),
+      "revets to original composer title when Q&A format is disabled"
+    );
+
+    await composerActionTitle.expand();
+    await composerActionTitle.selectKitSelectRowByName(
+      I18n.t("composer.composer_actions.create_as_qa.label")
+    );
+
+    await fillIn("#reply-title", "this is some random topic title");
+    await fillIn(".d-editor-input", "this is some random body");
+    await click(".create");
+
+    assert.ok(
+      createAsQASetInRequest,
+      "submits the right request to create topic as Q&A formatted"
+    );
+  });
+});

--- a/test/javascripts/acceptance/composer-test.js
+++ b/test/javascripts/acceptance/composer-test.js
@@ -59,7 +59,7 @@ acceptance("Discourse Question Answer - composer", function (needs) {
     assert.notStrictEqual(
       query(".action-title").textContent.trim(),
       I18n.t("composer.create_qa.label"),
-      "revets to original composer title when Q&A format is disabled"
+      "reverts to original composer title when Q&A format is disabled"
     );
 
     await composerActionTitle.expand();

--- a/test/javascripts/acceptance/question-answer-test.js
+++ b/test/javascripts/acceptance/question-answer-test.js
@@ -14,7 +14,6 @@ import { cloneJSON } from "discourse-common/lib/object";
 const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
 
 function qaEnabledTopicResponse() {
-  topicResponse.post_stream.posts[0]["qa_enabled"] = true;
   topicResponse.post_stream.posts[0]["qa_vote_count"] = 0;
   topicResponse.post_stream.posts[0]["comments_count"] = 1;
 
@@ -29,7 +28,6 @@ function qaEnabledTopicResponse() {
     },
   ];
 
-  topicResponse.post_stream.posts[1]["qa_enabled"] = true;
   topicResponse.post_stream.posts[1]["qa_vote_count"] = 2;
   topicResponse.post_stream.posts[1]["qa_has_votes"] = true;
   topicResponse.post_stream.posts[1]["comments_count"] = 6;
@@ -88,7 +86,7 @@ function qaEnabledTopicResponse() {
     },
   ];
 
-  topicResponse.post_stream["qa_enabled"] = true;
+  topicResponse["is_qa"] = true;
 
   return topicResponse;
 }


### PR DESCRIPTION
Before this change, we were depending on setting a special tag or
enabling the Q&A format at the category level. However, we want to
simplify this by simply making this a topic level setting.

### Screenshots

![Peek 2022-03-21 15-52](https://user-images.githubusercontent.com/4335742/159222040-ecf9269b-567a-47bf-8c14-12da784afda7.gif)
