### PR TITLE
FIX: Mobile styling regression

### DIFF
--- a/assets/stylesheets/mobile/question-answer.scss
+++ b/assets/stylesheets/mobile/question-answer.scss
@@ -1,4 +1,4 @@
-.qa-is-answer {
+.qa-topic {
   .qa-answers-header {
     padding: 0;
     padding-bottom: 1em;


### PR DESCRIPTION
Since https://github.com/discourse/discourse-question-answer/commit/e572ec7cab5293e56d8f7035041e52be63977d87, the `qa-is-answer` class is no longer used. 