### PR TITLE
FEATURE: Create notification when a comment is created.

### DIFF
--- a/app/controllers/question_answer/comments_controller.rb
+++ b/app/controllers/question_answer/comments_controller.rb
@@ -28,16 +28,16 @@ module QuestionAnswer
         raise Discourse::InvalidAccess
       end
 
-      comment = QuestionAnswerComment.new(
+      comment = QuestionAnswer::CommentCreator.create(
         user: current_user,
         post_id: @post.id,
         raw: comments_params[:raw]
       )
 
-      if comment.save
-        render_serialized(comment, QuestionAnswerCommentSerializer, root: false)
-      else
+      if comment.errors.present?
         render_json_error(comment.errors.full_messages, status: 403)
+      else
+        render_serialized(comment, QuestionAnswerCommentSerializer, root: false)
       end
     end
 

--- a/assets/javascripts/discourse/widgets/qa-comment.js
+++ b/assets/javascripts/discourse/widgets/qa-comment.js
@@ -6,12 +6,16 @@ import { formatUsername } from "discourse/lib/utilities";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 
+export function buildAnchorId(qaCommentId) {
+  return `qa-comment-${qaCommentId}`;
+}
+
 export default createWidget("qa-comment", {
   tagName: "div.qa-comment",
   buildKey: (attrs) => `qa-comment-${attrs.id}`,
 
-  buildClasses(attrs) {
-    return [`qa-comment-${attrs.id}`];
+  buildId(attrs) {
+    return buildAnchorId(attrs.id);
   },
 
   sendShowLogin() {

--- a/assets/javascripts/discourse/widgets/question-answer-user-commented-notification-item.js
+++ b/assets/javascripts/discourse/widgets/question-answer-user-commented-notification-item.js
@@ -1,0 +1,21 @@
+import { DefaultNotificationItem } from "discourse/widgets/default-notification-item";
+import { createWidgetFrom } from "discourse/widgets/widget";
+import { iconNode } from "discourse-common/lib/icon-library";
+import { postUrl } from "discourse/lib/utilities";
+import { buildAnchorId } from "../widgets/qa-comment";
+
+createWidgetFrom(
+  DefaultNotificationItem,
+  "question-answer-user-commented-notification-item",
+  {
+    url(data) {
+      const attrs = this.attrs;
+      const url = postUrl(attrs.slug, attrs.topic_id, attrs.post_number);
+      return `${url}#${buildAnchorId(data.qa_comment_id)}`;
+    },
+
+    icon() {
+      return iconNode("comment");
+    },
+  }
+);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,11 @@
 en:
   js:
+    notifications:
+      question_answer_user_commented: "<span>%{username}</span> %{description}"
+      titles:
+        question_answer_user_commented: "new comment"
+      popup:
+        question_answer_user_commented: '%{username} commented in "%{topic}" - %{site_title}'
     composer:
       create_qa:
         label: "Create Q&A topic"

--- a/lib/question_answer/comment_creator.rb
+++ b/lib/question_answer/comment_creator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module QuestionAnswer
+  class CommentCreator
+    def self.create(attributes)
+      qa_comment = QuestionAnswerComment.new(attributes)
+
+      ActiveRecord::Base.transaction do
+        if qa_comment.save
+          create_commented_notification(qa_comment)
+        end
+      end
+
+      qa_comment
+    end
+
+    def self.create_commented_notification(qa_comment)
+      return if qa_comment.user_id == qa_comment.post.user_id
+
+      Notification.create!(
+        notification_type: Notification.types[:question_answer_user_commented],
+        user_id: qa_comment.post.user_id,
+        post_number: qa_comment.post.post_number,
+        topic_id: qa_comment.post.topic_id,
+        data: {
+          qa_comment_id: qa_comment.id,
+          display_username: qa_comment.user.username
+        }.to_json,
+      )
+
+      PostAlerter.create_notification_alert(
+        user: qa_comment.post.user,
+        post: qa_comment.post,
+        notification_type: Notification.types[:question_answer_user_commented],
+        username: qa_comment.user.username
+      )
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -18,6 +18,7 @@ after_initialize do
     ../lib/question_answer/engine.rb
     ../lib/question_answer/vote_manager.rb
     ../lib/question_answer/guardian.rb
+    ../lib/question_answer/comment_creator.rb
     ../extensions/post_extension.rb
     ../extensions/post_serializer_extension.rb
     ../extensions/topic_extension.rb

--- a/test/javascripts/acceptance/notifications-test.js
+++ b/test/javascripts/acceptance/notifications-test.js
@@ -1,0 +1,56 @@
+import I18n from "I18n";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Discourse Question Answer - notifications", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    server.get("/notifications", () => {
+      return helper.response({
+        notifications: [
+          {
+            id: 1,
+            user_id: 26,
+            notification_type: 35,
+            post_number: 1,
+            topic_id: 59,
+            fancy_title: "some fancy title",
+            slug: "some-slug",
+            data: {
+              display_username: "someuser",
+              qa_comment_id: 123,
+            },
+          },
+        ],
+        total_rows_notifications: 1,
+      });
+    });
+  });
+
+  test("viewing comments notifications", async (assert) => {
+    await visit("/u/eviltrout/notifications");
+
+    const notification = queryAll("ul.notifications")[0];
+
+    assert.strictEqual(
+      notification.textContent,
+      "someuser some fancy title",
+      "displays the username of user that commented and topic's title in notification"
+    );
+
+    assert.ok(
+      notification
+        .querySelector("a")
+        .href.includes("/t/some-slug/59#qa-comment-123"),
+      "displays a link with a hash fragment pointing to the comment id"
+    );
+
+    assert.strictEqual(
+      notification.querySelector("a").title,
+      I18n.t("notifications.titles.question_answer_user_commented"),
+      "displays the right title"
+    );
+  });
+});

--- a/test/javascripts/acceptance/question-answer-test.js
+++ b/test/javascripts/acceptance/question-answer-test.js
@@ -234,7 +234,7 @@ acceptance("Discourse Question Answer - anon user", function (needs) {
 
   test("voting a comment", async function (assert) {
     await visit("/t/280");
-    await click("#post_2 .qa-comment-2 .qa-button-upvote");
+    await click("#post_2 #qa-comment-2 .qa-button-upvote");
 
     assert.ok(exists(".login-modal"), "displays the login modal");
   });
@@ -504,12 +504,12 @@ acceptance("Discourse Question Answer - logged in user", function (needs) {
     await visit("/t/280");
 
     assert.ok(
-      !exists("#post_2 .qa-comment-2 .qa-comment-actions-vote-count"),
+      !exists("#post_2 #qa-comment-2 .qa-comment-actions-vote-count"),
       "does not display element if vote count is zero"
     );
 
     assert.strictEqual(
-      query("#post_2 .qa-comment-3 .qa-comment-actions-vote-count").textContent,
+      query("#post_2 #qa-comment-3 .qa-comment-actions-vote-count").textContent,
       "3",
       "displays the right vote count"
     );
@@ -518,18 +518,18 @@ acceptance("Discourse Question Answer - logged in user", function (needs) {
   test("voting on a comment and removing vote", async function (assert) {
     await visit("/t/280");
 
-    await click("#post_2 .qa-comment-2 .qa-button-upvote");
+    await click("#post_2 #qa-comment-2 .qa-button-upvote");
 
     assert.strictEqual(
-      query("#post_2 .qa-comment-2 .qa-comment-actions-vote-count").textContent,
+      query("#post_2 #qa-comment-2 .qa-comment-actions-vote-count").textContent,
       "1",
       "updates the comment vote count correctly"
     );
 
-    await click("#post_2 .qa-comment-2 .qa-button-upvote");
+    await click("#post_2 #qa-comment-2 .qa-button-upvote");
 
     assert.ok(
-      !exists("#post_2 .qa-comment-2 .qa-comment-actions-vote-count"),
+      !exists("#post_2 #qa-comment-2 .qa-comment-actions-vote-count"),
       "updates the comment vote count correctly"
     );
   });


### PR DESCRIPTION
When a comment is created, we want to alert that creator of the post
where the comment is made. We may want to consider consolidatig
notifications in the future but this will do for the initial version of
the plugin.

To link to the comment, we rely on a hash fragment in the URL. Ideally,
we want to disable the post's highlight and highlight the comment
instead. However, this requires alot of hacking and our focus now is to
get an MVP out. If we really want to sugar coat this in the future, it
is still possible.

## Screenshots

![Screenshot from 2022-03-28 15-06-32](https://user-images.githubusercontent.com/4335742/160344309-939d499e-cdaf-4271-a7f3-6bfe2874c106.png)