### PR TITLE
FIX: Avoid including computed property in widget/post attributes.

### DIFF
--- a/assets/javascripts/discourse/initializers/qa-edits.js
+++ b/assets/javascripts/discourse/initializers/qa-edits.js
@@ -1,6 +1,5 @@
 import I18n from "I18n";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { readOnly } from "@ember/object/computed";
 
 export const ORDER_BY_ACTIVITY_FILTER = "activity";
 const pluginId = "discourse-question-answer";
@@ -32,7 +31,7 @@ function initPlugin(api) {
   );
 
   api.removePostMenuButton("reply", (attrs) => {
-    return attrs.isQA && attrs.post_number !== 1;
+    return attrs.qa_has_votes !== undefined && attrs.post_number !== 1;
   });
 
   api.removePostMenuButton("like", (_attrs, _state, siteSetting) => {
@@ -105,7 +104,7 @@ function initPlugin(api) {
     const result = [];
     const post = helper.getModel();
 
-    if (!post.isQA) {
+    if (!post.topic.is_qa) {
       return result;
     }
 
@@ -170,7 +169,7 @@ function initPlugin(api) {
     const attrs = helper.widget.attrs;
 
     if (
-      attrs.isQA &&
+      attrs.qa_has_votes !== undefined &&
       !attrs.reply_to_post_number &&
       !helper.widget.state.filteredRepliesShown
     ) {
@@ -196,17 +195,9 @@ function initPlugin(api) {
     return result;
   });
 
-  api.modifyClass("model:post", {
-    pluginId,
-
-    isQA: readOnly("topic.is_qa"),
-  });
-
   api.includePostAttributes(
-    "isQA",
     "comments",
     "comments_count",
-    "qa_disable_like",
     "qa_user_voted_direction",
     "qa_has_votes"
   );

--- a/test/javascripts/acceptance/question-answer-test.js
+++ b/test/javascripts/acceptance/question-answer-test.js
@@ -19,6 +19,7 @@ const topicList = cloneJSON(discoveryFixtures["/latest.json"]);
 function qaEnabledTopicResponse() {
   topicResponse.post_stream.posts[0]["qa_vote_count"] = 0;
   topicResponse.post_stream.posts[0]["comments_count"] = 1;
+  topicResponse.post_stream.posts[0]["qa_has_votes"] = false;
 
   topicResponse.post_stream.posts[0]["comments"] = [
     {
@@ -243,6 +244,17 @@ acceptance("Discourse Question Answer - anon user", function (needs) {
 acceptance("Discourse Question Answer - logged in user", function (needs) {
   setupQA(needs);
   needs.user();
+
+  test("Q&A features do not leak into non-Q&A topics", async function (assert) {
+    await visit("/t/130");
+
+    assert.ok(exists("#post_1 button.reply"), "displays the reply button");
+
+    assert.notOk(
+      exists(".qa-answers-header"),
+      "does not display the Q&A answers header"
+    );
+  });
 
   test("non Q&A topics do not have Q&A specific class on body tag", async function (assert) {
     await visit("/t/130");


### PR DESCRIPTION
There is some behaviour in core that tries to override the computed
properties in certain scenarios. Instead, I opted for the easier and
less risky way out here but relying on other post attributes to obtain
the same end result.