### PR TITLE
FIX: Incorrect posts when loading posts near a given post number.

### DIFF
--- a/extensions/topic_view_extension.rb
+++ b/extensions/topic_view_extension.rb
@@ -2,7 +2,7 @@
 
 module QuestionAnswer
   module TopicViewExtension
-    def self.included(base)
+    def self.prepended(base)
       base.attr_accessor(
         :comments,
         :comments_counts,
@@ -19,6 +19,70 @@ module QuestionAnswer
         # Change ORDER_BY_ACTIVITY_FILTER on the client side when the value here is changed
         base.const_set :ACTIVITY_FILTER, "activity"
       end
+    end
+
+    # Monkey patch core's method. In an ideal world, we wouldn't have to do this here but `TopicView` in core does not
+    # yet properly support ordering posts in any other order except by `Post#sort_order` and several methods in
+    # core's `TopicView` is strongly tied to the assumption that posts are always ordered by `Post#sort_order`. Fixing
+    # core is hard and risky so we will just carry this monkey patch instead. There is also a small performance tradeoff
+    # here in the following implementation. In PostgreSQL, we basically have to scan for every single posts in order
+    # to figure out what the "row_number" for each post. From there, we can then properly fetch the window of posts
+    # near a given post number.
+    def filter_posts_near(post_number)
+      return super unless topic.is_qa?
+      return super if @filter == TopicView::ACTIVITY_FILTER
+
+      post_number = 1 if post_number == 0
+
+      cte_query = <<~SQL
+      WITH rows AS (
+        WITH posts AS (
+          #{@filtered_posts.to_sql}
+        )
+        SELECT
+          id,
+          post_number,
+          ROW_NUMBER() OVER () AS row_number
+        FROM posts
+      )
+      SQL
+
+      row_number, max_row_number = DB.query_single(<<~SQL)
+      #{cte_query}
+      SELECT
+        row_number,
+        (SELECT row_number FROM rows ORDER BY row_number DESC LIMIT 1) AS max_row_number
+      FROM rows
+      WHERE rows.post_number = #{post_number.to_i}
+      SQL
+
+      row_number = 1 if row_number.blank? # Post number does not exist so load from first post.
+
+      posts_before = (@limit.to_f / 4).floor
+      posts_before = 1 if posts_before.zero?
+      posts_after = @limit - posts_before - 1
+
+      range =
+        # Lower boundary window
+        if (row_number - posts_before) <= 0
+          1..(@limit - (row_number - 1))
+        # Upper boundary window
+        elsif (max_row_number - row_number) < posts_after
+          (max_row_number - @limit + 1)..max_row_number
+        # Any other window in between.
+        else
+          (row_number - posts_before)..(row_number + posts_after)
+        end
+
+      post_ids = DB.query_single(<<~SQL)
+      #{cte_query}
+      SELECT
+        id
+      FROM rows
+      WHERE rows.row_number IN (#{range.to_a.join(",")})
+      SQL
+
+      filter_posts_by_ids(post_ids)
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -58,8 +58,8 @@ after_initialize do
     include QuestionAnswer::TopicExtension
   end
 
-  class ::TopicView
-    include QuestionAnswer::TopicViewExtension
+  reloadable_patch do
+    TopicView.prepend(QuestionAnswer::TopicViewExtension)
   end
 
   class ::TopicViewSerializer


### PR DESCRIPTION
Moneky patch core's method. In an ideal world, we wouldn't have to do this here but `TopicView` in core does not
yet properly support ordering posts in any other order except by `Post#sort_order` and several methods in
core's `TopicView` is strongly tied to the assumption that posts are always ordered by `Post#sort_order`. Fixing
core is hard and risky so we will just carry this monkey patch instead. There is also a small performance tradeoff
here in the following implementation. In PostgreSQL, we basically have to scan for every single posts in order
to figure out what the "row_number" for each post. From there, we can then properly fetch the window of posts
near a given post number.

Another alternative to this solution here is to rely on `Post#sort_order` and update the column of all posts
whenever a post is voted on or created in the topic. We basically trade-off voting and post creation performance
for a more efficient read query.