### PR TITLE
FIX: Invalid translation key when deleting comment.

### DIFF
--- a/assets/javascripts/discourse/widgets/qa-comment-actions.js
+++ b/assets/javascripts/discourse/widgets/qa-comment-actions.js
@@ -26,7 +26,7 @@ createWidget("qa-comment-actions", {
 
   deleteComment(data) {
     return bootbox.confirm(
-      I18n.t("qa.post.qa_comment.delete_confirm"),
+      I18n.t("qa.post.qa_comment.delete.confirm"),
       I18n.t("no_value"),
       I18n.t("yes_value"),
       (result) => {


### PR DESCRIPTION
No meaningful test I can add here unless we actually raise an error for a missing translation key used in the text environment. 