### PR TITLE
UX: add spacing between post controls and comments

### DIFF
--- a/assets/stylesheets/common/question-answer.scss
+++ b/assets/stylesheets/common/question-answer.scss
@@ -57,6 +57,7 @@
 
 .qa-comments {
   width: 100%;
+  padding-top: 5px;
 }
 
 .qa-comment {


### PR DESCRIPTION
Before:

<img width="785" alt="Screen Shot 2022-05-23 at 19 43 20" src="https://user-images.githubusercontent.com/5732281/169839425-c8ee18de-7e17-42e9-82d3-a9f4c6b07d8c.png">

After:

<img width="791" alt="Screen Shot 2022-05-23 at 19 42 56" src="https://user-images.githubusercontent.com/5732281/169839410-7cda1883-5801-4009-a1ff-afdc41fbab04.png">
