### PR TITLE
UX: fix styling when Q&A topic is sorted by activity

### DIFF
--- a/assets/stylesheets/common/question-answer.scss
+++ b/assets/stylesheets/common/question-answer.scss
@@ -1,4 +1,5 @@
-.qa-topic {
+.qa-topic,
+.qa-topic-sort-by-activity {
   .time-gap,
   .topic-post-visited-line,
   .timeline-date-wrapper,

--- a/assets/stylesheets/mobile/question-answer.scss
+++ b/assets/stylesheets/mobile/question-answer.scss
@@ -1,4 +1,5 @@
-.qa-topic {
+.qa-topic,
+.qa-topic-sort-by-activity {
   .qa-answers-header {
     padding: 0;
     padding-bottom: 1em;


### PR DESCRIPTION
Before:

<img width="291" alt="Screen Shot 2022-05-26 at 13 38 20" src="https://user-images.githubusercontent.com/5732281/170446331-b4e15bab-f110-4b0d-9ff5-3ebde2be2ed9.png">

After:

<img width="292" alt="Screen Shot 2022-05-26 at 13 37 44" src="https://user-images.githubusercontent.com/5732281/170446318-8abd9861-a33f-44ac-80f9-3b33b6a833d5.png">
