### PR TITLE
FIX: disable submit comment button when required conditions are not met

### DIFF
--- a/assets/javascripts/discourse/widgets/qa-comment-editor.js
+++ b/assets/javascripts/discourse/widgets/qa-comment-editor.js
@@ -12,7 +12,7 @@ createWidget("qa-comment-editor", {
   },
 
   defaultState(attrs) {
-    return { updatingComment: false, value: attrs.raw };
+    return { value: attrs.raw, submitDisabled: true };
   },
 
   html(attrs, state) {
@@ -20,7 +20,7 @@ createWidget("qa-comment-editor", {
       this.attach("qa-comment-composer", attrs),
       this.attach("button", {
         action: "editComment",
-        disabled: state.updatingComment,
+        disabled: state.submitDisabled,
         contents: I18n.t("qa.post.qa_comment.edit"),
         icon: "pencil-alt",
         className: "btn-primary qa-comment-editor-submit",
@@ -35,6 +35,9 @@ createWidget("qa-comment-editor", {
 
   updateValue(value) {
     this.state.value = value;
+    this.state.submitDisabled =
+      value.length < this.siteSettings.min_post_length ||
+      value.length > this.siteSettings.qa_comment_max_raw_length;
   },
 
   keyDown(e) {
@@ -44,7 +47,7 @@ createWidget("qa-comment-editor", {
   },
 
   editComment() {
-    this.state.updatingComment = true;
+    this.state.submitDisabled = true;
 
     return ajax("/qa/comments", {
       type: "PUT",
@@ -59,7 +62,7 @@ createWidget("qa-comment-editor", {
       })
       .catch(popupAjaxError)
       .finally(() => {
-        this.state.updatingComment = false;
+        this.state.submitDisabled = false;
       });
   },
 });

--- a/assets/javascripts/discourse/widgets/qa-comments-menu-composer.js
+++ b/assets/javascripts/discourse/widgets/qa-comments-menu-composer.js
@@ -8,7 +8,7 @@ createWidget("qa-comments-menu-composer", {
   buildKey: (attrs) => `qa-comments-menu-composer-${attrs.id}`,
 
   defaultState() {
-    return { value: "", creatingPost: false };
+    return { value: "", submitDisabled: true };
   },
 
   html(attrs, state) {
@@ -19,7 +19,7 @@ createWidget("qa-comments-menu-composer", {
     result.push(
       this.attach("button", {
         action: "submitComment",
-        disabled: state.creatingPost,
+        disabled: state.submitDisabled,
         contents: I18n.t("qa.post.qa_comment.submit"),
         icon: "reply",
         className: "btn-primary qa-comments-menu-composer-submit",
@@ -45,10 +45,13 @@ createWidget("qa-comments-menu-composer", {
 
   updateValue(value) {
     this.state.value = value;
+    this.state.submitDisabled =
+      value.length < this.siteSettings.min_post_length ||
+      value.length > this.siteSettings.qa_comment_max_raw_length;
   },
 
   submitComment() {
-    this.state.creatingPost = true;
+    this.state.submitDisabled = true;
 
     return ajax("/qa/comments", {
       type: "POST",
@@ -61,7 +64,7 @@ createWidget("qa-comments-menu-composer", {
       })
       .catch(popupAjaxError)
       .finally(() => {
-        this.state.creatingPost = false;
+        this.state.submitDisabled = false;
       });
   },
 });

--- a/test/javascripts/acceptance/question-answer-test.js
+++ b/test/javascripts/acceptance/question-answer-test.js
@@ -126,7 +126,7 @@ function setupQA(needs) {
   needs.settings({
     qa_enabled: true,
     min_post_length: 5,
-    qa_comment_max_raw_length: 20,
+    qa_comment_max_raw_length: 50,
   });
 
   needs.hooks.afterEach(() => {
@@ -359,20 +359,35 @@ acceptance("Discourse Question Answer - logged in user", function (needs) {
       "displays the right message about raw length when it is too short"
     );
 
+    assert.ok(
+      exists(".qa-comments-menu-composer-submit[disabled=true]"),
+      "submit comment button is disabled"
+    );
+
     await fillIn(".qa-comment-composer-textarea", "a".repeat(6));
 
     assert.strictEqual(
       query(".qa-comment-composer-flash").textContent.trim(),
-      I18n.t("qa.post.qa_comment.composer.length_ok", { count: 14 }),
+      I18n.t("qa.post.qa_comment.composer.length_ok", { count: 44 }),
       "displays the right message about raw length when it is OK"
     );
 
-    await fillIn(".qa-comment-composer-textarea", "a".repeat(21));
+    assert.notOk(
+      exists(".qa-comments-menu-composer-submit[disabled=true]"),
+      "submit comment button is enabled"
+    );
+
+    await fillIn(".qa-comment-composer-textarea", "a".repeat(51));
 
     assert.strictEqual(
       query(".qa-comment-composer-flash").textContent.trim(),
-      I18n.t("qa.post.qa_comment.composer.too_long", { count: 20 }),
+      I18n.t("qa.post.qa_comment.composer.too_long", { count: 50 }),
       "displays the right message about raw length when it is too long"
+    );
+
+    assert.ok(
+      exists(".qa-comments-menu-composer-submit[disabled=true]"),
+      "submit comment button is disabled"
     );
   });
 
@@ -439,12 +454,31 @@ acceptance("Discourse Question Answer - logged in user", function (needs) {
     );
 
     await click("#post_1 .qa-comment-actions-edit-link");
+
+    await fillIn(".qa-comment-composer-textarea", "a".repeat(4));
+
+    assert.strictEqual(
+      query(".qa-comment-composer-flash").textContent.trim(),
+      I18n.t("qa.post.qa_comment.composer.too_short", { count: 5 }),
+      "displays the right message about raw length when it is too short"
+    );
+
+    assert.ok(
+      exists(".qa-comment-editor-submit[disabled=true]"),
+      "submit comment button is disabled"
+    );
+
     await fillIn("#post_1 .qa-comment-editor-1 textarea", "editing this");
 
     assert.strictEqual(
       query(".qa-comment-composer-flash").textContent.trim(),
-      I18n.t("qa.post.qa_comment.composer.length_ok", { count: 8 }),
+      I18n.t("qa.post.qa_comment.composer.length_ok", { count: 38 }),
       "displays the right message when comment lenght is OK"
+    );
+
+    assert.notOk(
+      exists(".qa-comment-editor-submit[disabled=true]"),
+      "submit comment button is enabled"
     );
 
     await click("#post_1 .qa-comment-editor-1 .qa-comment-editor-submit");


### PR DESCRIPTION
This commit disables the comment submit button if the comment length is less than `min_post_length` or more than `qa_comment_max_raw_length`.

Before:

<img width="721" alt="Screen Shot 2022-05-26 at 19 36 41" src="https://user-images.githubusercontent.com/5732281/170504214-6b7a7731-a2c2-4a2b-92b0-8591eaa5520d.png">

After:

<img width="725" alt="Screen Shot 2022-05-26 at 19 36 03" src="https://user-images.githubusercontent.com/5732281/170504204-8baeaa11-66ad-49f1-adc8-8539ad48a349.png">
