### PR TITLE
UX: wrap comments to prevent overflow

### DIFF
--- a/assets/stylesheets/common/question-answer.scss
+++ b/assets/stylesheets/common/question-answer.scss
@@ -68,6 +68,7 @@
   flex-direction: row;
   align-items: flex-start;
   padding: 0.7em 0;
+  word-break: break-word;
 
   &.qa-comment-deleted {
     background-color: var(--danger-low-mid);


### PR DESCRIPTION
Before:

<img width="1275" alt="Screen Shot 2022-05-30 at 17 57 30" src="https://user-images.githubusercontent.com/5732281/170994626-10043570-08fe-42bf-a7ff-2e59b4e6136e.png">

After:

<img width="784" alt="Screen Shot 2022-05-30 at 17 57 18" src="https://user-images.githubusercontent.com/5732281/170994596-a820e86f-0fd6-4c5c-8230-fb1a7585fa8b.png">
