### PR TITLE
FIX: do not let users bypass qa_undo_vote_action_window

### DIFF
--- a/lib/question_answer/vote_manager.rb
+++ b/lib/question_answer/vote_manager.rb
@@ -55,6 +55,7 @@ module QuestionAnswer
     end
 
     def self.can_undo(post, user)
+      return true if post.qa_last_voted(user.id).blank?
       window = SiteSetting.qa_undo_vote_action_window.to_i
       window.zero? || post.qa_last_voted(user.id).to_i > window.minutes.ago.to_i
     end

--- a/spec/requests/question_answer/votes_controller_spec.rb
+++ b/spec/requests/question_answer/votes_controller_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe QuestionAnswer::VotesController do
 
       expect(response.status).to eq(403)
     end
+
+    it 'should return 403 after qa_undo_vote_action_window' do
+      SiteSetting.qa_undo_vote_action_window = 1
+
+      post "/qa/vote.json", params: { post_id: answer.id }
+
+      expect(response.status).to eq(200)
+
+      freeze_time 2.minutes.from_now do
+        post '/qa/vote.json', params: { post_id: answer.id, direction: QuestionAnswerVote.directions[:down] }
+
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)['errors'][0]).to eq(I18n.t('vote.error.undo_vote_action_window', minutes: 1))
+      end
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
Currently the users could get around `qa_undo_vote_action_window` by
performing the inverse voting and thereby nullifying the vote. This
commit adds a verification to check if a user has already voted and
does not allow changing the vote after `qa_undo_vote_action_window`.