### PR TITLE
UX: add spacing between sorting buttons

### DIFF
--- a/assets/stylesheets/common/question-answer.scss
+++ b/assets/stylesheets/common/question-answer.scss
@@ -39,7 +39,7 @@
       }
 
       + .btn {
-        border-left: none;
+        margin-left: 0.3em;
       }
 
       &:first-of-type {


### PR DESCRIPTION
Before:

<img width="202" alt="Screen Shot 2022-06-07 at 12 00 08" src="https://user-images.githubusercontent.com/5732281/172311636-c9253140-3e6f-4b26-b68a-4872fcb90e57.png">

After:

<img width="202" alt="Screen Shot 2022-06-07 at 12 01 47" src="https://user-images.githubusercontent.com/5732281/172311647-806735a3-4fcf-41da-a0ba-3d4e3e3f89fa.png">
