### PR TITLE
FIX: do not warn users for sequential replies on Q&A topic

### DIFF
--- a/extensions/composer_messages_finder_extension.rb
+++ b/extensions/composer_messages_finder_extension.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module QuestionAnswer
+  module ComposerMessagesFinderExtension
+    def check_sequential_replies
+      return if @topic.present? && @topic.is_qa?
+      super
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -27,6 +27,7 @@ after_initialize do
     ../extensions/topic_view_serializer_extension.rb
     ../extensions/topic_view_extension.rb
     ../extensions/user_extension.rb
+    ../extensions/composer_messages_finder_extension.rb
     ../app/validators/question_answer_comment_validator.rb
     ../app/controllers/question_answer/votes_controller.rb
     ../app/controllers/question_answer/comments_controller.rb
@@ -56,6 +57,7 @@ after_initialize do
     TopicListItemSerializer.include(QuestionAnswer::TopicListItemSerializerExtension)
     User.include(QuestionAnswer::UserExtension)
     Guardian.include(QuestionAnswer::Guardian)
+    ComposerMessagesFinder.prepend(QuestionAnswer::ComposerMessagesFinderExtension)
   end
 
   # TODO: Performance of the query degrades as the number of posts a user has voted

--- a/spec/components/composer_messages_finder_spec.rb
+++ b/spec/components/composer_messages_finder_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'composer_messages_finder'
+
+describe ComposerMessagesFinder do
+
+  context '.check_sequential_replies' do
+    fab!(:user) { Fabricate(:user) }
+    fab!(:topic) { Fabricate(:topic) }
+    fab!(:qa_topic) { Fabricate(:topic, subtype: Topic::QA_SUBTYPE) }
+
+    before do
+      SiteSetting.educate_until_posts = 4
+      SiteSetting.sequential_replies_threshold = 2
+
+      5.times do
+        Fabricate(:post, topic: topic, user: user)
+      end
+    end
+
+    it "notify user about sequential replies for regular topics" do
+      finder = ComposerMessagesFinder.new(user, composer_action: 'reply', topic_id: topic.id)
+      expect(finder.check_sequential_replies).to be_present
+    end
+
+    it "doesn't notify user about sequential replies for Q&A topics" do
+      finder = ComposerMessagesFinder.new(user, composer_action: 'reply', topic_id: qa_topic.id)
+      expect(finder.check_sequential_replies).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
Suppresses the sequential replies education message for Q&A topics.

![sequential_replies](https://user-images.githubusercontent.com/5732281/172605046-6da01e32-6d47-45df-93fd-48ef83dc01d0.png)
