### PR TITLE
Temporarily disable crawler view test

### DIFF
--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -44,6 +44,7 @@ describe TopicsController do
     end
 
     it "includes QA comments for crawler view" do
+      pending "temporarily disable crawler view test while the perf issues are being worked on"
       get "/t/#{topic.slug}/#{topic.id}.html"
 
       expect(response.status).to eq(200)


### PR DESCRIPTION
Temporarily disable crawler view test while we work on perf issues.