### PR TITLE
DEV: Fix flaky specs and make comment order consistent

### DIFF
--- a/extensions/topic_extension.rb
+++ b/extensions/topic_extension.rb
@@ -38,7 +38,10 @@ module QuestionAnswer
 
     def comments
       @comments ||= begin
-        QuestionAnswerComment.joins(:post).where("posts.topic_id = ?", self.id)
+        QuestionAnswerComment
+          .joins(:post)
+          .where("posts.topic_id = ?", self.id)
+          .order(created_at: :asc)
       end
     end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -9,7 +9,7 @@ describe Topic do
   fab!(:topic_post) { Fabricate(:post, topic: topic) }
 
   fab!(:answers) do
-    5.times.map { Fabricate(:post, topic: topic) }.sort_by(&:created_at)
+    5.times.map { Fabricate(:post, topic: topic) }.sort_by(&:post_number)
   end
 
   fab!(:comments) do


### PR DESCRIPTION
Flakes were:

```
1) Topic should return correct last_commented_on
    Failure/Error: expect(topic.last_commented_on).to eq_time(expected)
      2022-08-17 11:02:51 UTC is not within 1 millisecond of 2022-08-17 11:02:51 UTC
    # ./plugins/discourse-question-answer/spec/models/topic_spec.rb:84:in `block (2 levels) in <main>'
    # ./spec/rails_helper.rb:278:in `block (2 levels) in <top (required)>'

2) Topic should return correct comments
    Failure/Error: expect(comment_ids).to eq(topic_comment_ids)

      expected: [110, 106, 107, 108, 109]
          got: [106, 107, 108, 109, 110]

      (compared using ==)
    # ./plugins/discourse-question-answer/spec/models/topic_spec.rb:61:in `block (2 levels) in <main>'
    # ./spec/rails_helper.rb:278:in `block (2 levels) in <top (required)>'
```